### PR TITLE
Fix "Error: init() not called, Hydra requires a configuration object."

### DIFF
--- a/lib/HydraLogger.js
+++ b/lib/HydraLogger.js
@@ -70,7 +70,18 @@ class HydraLogger extends HydraPlugin {
    * @override
    */
   onServiceReady() {
-    this.hydra.on('log', entry => this._logger.pino[entry.type](entry));
+
+    this.hydra.on('log', entry => {
+      if (typeof(entry.msg) === 'object') {
+        const entryObj = entry.msg;
+        entry.msg = entryObj.message ? entryObj.message : JSON.stringify(entryObj);
+        if (entryObj.stack) {
+          entry.stack = entryObj.stack;
+        }
+      }
+
+      this._logger.pino[entry.type](entry);
+    });
   }
 }
 

--- a/lib/HydraLogger.js
+++ b/lib/HydraLogger.js
@@ -4,7 +4,7 @@ const HydraPlugin = require('hydra-plugin');
 const PinoLogger = require('./PinoLogger');
 
 const hydraOpts = (opts, hydra) => {
-  let augment = {serviceName: hydra.getServiceName()};
+  let augment = {serviceName: opts.serviceName};
   if (opts.augment) {
     opts.augment = Object.assign(opts.augment, augment);
     return opts;


### PR DESCRIPTION
Generate the hydra service project with logger, `npm install` and `npm start`, following ERR throw

```Error initializing hydra Error: init() not called, Hydra requires a configuration object.
    at IHydra._getServiceName (/Users/khoinqq/Working/opensource/hydra-event-bus-service/node_modules/hydra/index.js:379:13)
    at IHydra.getServiceName (/Users/khoinqq/Working/opensource/hydra-event-bus-service/node_modules/hydra/index.js:1818:18)
    at hydraOpts (/Users/khoinqq/Working/opensource/hydra-event-bus-service/node_modules/fwsp-logger/lib/HydraLogger.js:7:37)
    at HydraPinoLogger (/Users/khoinqq/Working/opensource/hydra-event-bus-service/node_modules/fwsp-logger/lib/HydraLogger.js:22:11)
    at HydraLogger.initLogger (/Users/khoinqq/Working/opensource/hydra-event-bus-service/node_modules/fwsp-logger/lib/HydraLogger.js:54:20)
    at HydraLogger.setConfig (/Users/khoinqq/Working/opensource/hydra-event-bus-service/node_modules/fwsp-logger/lib/HydraLogger.js:40:10)
    at Promise.series (/Users/khoinqq/Working/opensource/hydra-event-bus-service/node_modules/hydra/index.js:107:74)
    at Array.map (native)
    at Function.Promise.series (/Users/khoinqq/Working/opensource/hydra-event-bus-service/node_modules/hydra/index.js:4:14)
    at loader (/Users/khoinqq/Working/opensource/hydra-event-bus-service/node_modules/hydra/index.js:107:24)
    at Promise (/Users/khoinqq/Working/opensource/hydra-event-bus-service/node_modules/hydra/index.js:212:16)
    at Promise._execute (/Users/khoinqq/Working/opensource/hydra-event-bus-service/node_modules/bluebird/js/release/debuggability.js:300:9)
    at Promise._resolveFromExecutor (/Users/khoinqq/Working/opensource/hydra-event-bus-service/node_modules/bluebird/js/release/promise.js:483:18)
    at new Promise (/Users/khoinqq/Working/opensource/hydra-event-bus-service/node_modules/bluebird/js/release/promise.js:79:10)
    at IHydra.init (/Users/khoinqq/Working/opensource/hydra-event-bus-service/node_modules/hydra/index.js:105:25)
    at IHydra.init (/Users/khoinqq/Working/opensource/hydra-event-bus-service/node_modules/hydra/index.js:1779:18)```

Why?
`HydraPinoLogger` init with a call to `hydra.getServiceName` which require hydra fully initialized, but it is not at this time.

Solution: Use hydra config service name instead