### PR TITLE
migrate to pino 5.x

### DIFF
--- a/lib/PinoLogger.js
+++ b/lib/PinoLogger.js
@@ -41,13 +41,19 @@ class PinoLogger {
       }
       this.initFile(logFilePath);
     }
-    if (!(opts.toConsole === false)) {
-      const pretty = pino.pretty();
-      this.pt.pipe(pretty);
-      pretty.pipe(process.stdout);
-    }
+    // if (!(opts.toConsole === false)) {
+    //   const pretty = pino.pretty();
+    //   this.pt.pipe(pretty);
+    //   pretty.pipe(process.stdout);
+    // }
     this.augment = opts.augment;
-    this.initPino({ serializers: this.serializers(opts.redact) });
+    this.initPino({
+      serializers: this.serializers(opts.redact),
+      prettyPrint: {
+        levelFirst: true
+      },
+      prettifier: require('pino-pretty')
+    });
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fwsp-logger",
-  "version": "0.3.3",
+  "version": "0.4.0",
   "author": {
     "name": "Eric Adum",
     "email": "eric@flywheelsports.com"
@@ -20,22 +20,22 @@
   "license": "MIT",
   "repository": "flywheelsports/fwsp-logger",
   "dependencies": {
-    "chokidar": "2.0.3",
-    "elasticsearch": "14.2.1",
+    "chokidar": "2.1.2",
+    "elasticsearch": "15.4.1",
     "fast-json-parse": "1.0.3",
     "hydra-express-plugin": "0.0.1",
     "hydra-plugin": "0.0.1",
-    "lodash": "4.17.5",
+    "lodash": "4.17.11",
     "minimist": "1.2.0",
-    "path": "0.12.7",
-    "pino": "4.15.0",
-    "pino-http": "^3.2.1",
-    "split2": "2.2.0"
+    "pino": "5.11.1",
+    "pino-http": "4.1.0",
+    "pino-pretty": "2.5.0",
+    "split2": "3.1.0"
   },
   "devDependencies": {
-    "chai": "4.1.2",
-    "eslint": "4.18.1",
-    "mocha": "5.0.1"
+    "chai": "4.2.0",
+    "eslint": "5.15.1",
+    "mocha": "6.0.2"
   },
   "bin": {
     "fwsp-logger": "index.js"


### PR DESCRIPTION
Needs more testing before production-ready, as there are some major changes in how Pino works in the `5.x` generation