### PR TITLE
use flatted for err seralization to prevent circular json crash

### DIFF
--- a/lib/PinoLogger.js
+++ b/lib/PinoLogger.js
@@ -5,6 +5,7 @@ const fork = require('child_process').fork;
 const PassThrough = require('stream').PassThrough;
 const fs = require('fs');
 const _ = require('lodash');
+const {parse, stringify} = require('flatted/cjs');
 
 /**
  * @name PinoLogger
@@ -122,7 +123,7 @@ class PinoLogger {
     let ret = err;
     if (err instanceof Error) {
       ret = Object.assign(
-        JSON.parse(JSON.stringify(err)),
+        parse(stringify(err)),
         {
           type: err.name || err.constructor.name,
           message: err.message,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fwsp-logger",
-  "version": "0.3.5",
+  "version": "0.4.0",
   "author": {
     "name": "Eric Adum",
     "email": "eric@flywheelsports.com"
@@ -23,6 +23,7 @@
     "chokidar": "2.1.2",
     "elasticsearch": "16.3.0",
     "fast-json-parse": "1.0.3",
+    "flatted": "^2.0.1",
     "hydra-express-plugin": "0.0.1",
     "hydra-plugin": "0.0.1",
     "lodash": "4.17.15",


### PR DESCRIPTION
Any service using the req.err logger was crashing when trying to log JSON with circular references. This PR replaces `JSON.parse(JSON.stringify())` with the safe `parse` and `stringify` provided by the `flatted` npm module.